### PR TITLE
shadow_item_cull_mask should reference light mask

### DIFF
--- a/doc/classes/Light2D.xml
+++ b/doc/classes/Light2D.xml
@@ -68,7 +68,7 @@
 			Smooth shadow gradient length.
 		</member>
 		<member name="shadow_item_cull_mask" type="int" setter="set_item_shadow_cull_mask" getter="get_item_shadow_cull_mask" default="1">
-			The shadow mask. Used with [LightOccluder2D] to cast shadows. Only occluders with a matching shadow mask will cast shadows.
+			The shadow mask. Used with [LightOccluder2D] to cast shadows. Only occluders with a matching light mask will cast shadows.
 		</member>
 		<member name="texture" type="Texture" setter="set_texture" getter="get_texture">
 			[Texture] used for the Light2D's appearance.


### PR DESCRIPTION
The mask of a `LightOccluder2D` is called "light mask" both in terms of its [API](https://docs.godotengine.org/en/3.1/classes/class_lightoccluder2d.html) as well as in the editor GUI:

![image](https://user-images.githubusercontent.com/3620703/71560779-60619b00-2a6e-11ea-9349-0ccb7a69edf4.png)

If I understand it correctly this mask is related to the `shadow_item_cull_mask` of a `Light2d`. Currently the docs of `shadow_item_cull_mask` says _only occluders with a matching **shadow mask** will cast shadows._ This is confusing ([example](https://github.com/godotengine/godot/issues/25992#issuecomment-500146943)) if the mask is called "light mask" on the occluder.